### PR TITLE
chore: use exivity fork

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,6 @@ jobs:
         helm repo add bitnami https://charts.bitnami.com/bitnami
 
     - name: Run chart-releaser
-      uses: helm/chart-releaser-action@v1.1.0
+      uses: exivity/chart-releaser-action@v1.1.0
       env:
         CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
I want to get rid of the 'allow only this 3rd party github action' exception when possible. This is the easiest solution!