### PR TITLE
chore: update tag pattern for image release

### DIFF
--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -3,7 +3,7 @@ name: Release Images
 on:
   push:
     tags:
-      - "*"
+      - "exivity-*"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Only release a public image for the exivity-* tags. 