### PR TITLE
chore: exclude dummy data after initial sync

### DIFF
--- a/charts/exivity/templates/dummy-data/job.yaml
+++ b/charts/exivity/templates/dummy-data/job.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app.kubernetes.io/component: dummy-data
     {{- include "exivity.labels" $ | indent 4 }}
+  annotations:
+    argocd.argoproj.io/sync: exclude
 spec:
   completions:             1
   ttlSecondsAfterFinished: 300


### PR DESCRIPTION
This will make sure dummy data only runs once after being initialized by argo and not for subsequent syncs.