### PR TITLE
chore: env variable for backend logging

### DIFF
--- a/charts/exivity/templates/chronos/deployment.yaml
+++ b/charts/exivity/templates/chronos/deployment.yaml
@@ -36,6 +36,9 @@ spec:
             requests:
               cpu:    "25m"
               memory: "50Mi"
+          env:
+            - name:   EXIVITY_BACKEND_LOG_LEVEL
+              value:  "{{ .Values.logLevel.backend }}"
           securityContext:
             runAsUser:  1000
             runAsGroup: 1000

--- a/charts/exivity/templates/edify/deployment.yaml
+++ b/charts/exivity/templates/edify/deployment.yaml
@@ -42,6 +42,9 @@ spec:
             requests:
               cpu:    "25m"
               memory: "50Mi"
+          env:
+            - name: EXIVITY_BACKEND_LOG_LEVEL
+              value: "{{ .Values.logLevel.backend }}"
           securityContext:
             runAsUser:  1000
             runAsGroup: 1000

--- a/charts/exivity/templates/executor/deployment.yaml
+++ b/charts/exivity/templates/executor/deployment.yaml
@@ -48,6 +48,9 @@ spec:
             requests:
               cpu:    "25m"
               memory: "50Mi"
+          env:
+            - name: EXIVITY_BACKEND_LOG_LEVEL
+              value: "{{ .Values.logLevel.backend }}"
           securityContext:
             runAsUser:  1000
             runAsGroup: 1000

--- a/charts/exivity/templates/griffon/deployment.yaml
+++ b/charts/exivity/templates/griffon/deployment.yaml
@@ -36,6 +36,9 @@ spec:
             requests:
               cpu:    "25m"
               memory: "50Mi"
+          env:
+            - name:   EXIVITY_BACKEND_LOG_LEVEL
+              value:  "{{ .Values.logLevel.backend }}"
           securityContext:
             runAsUser:  1000
             runAsGroup: 1000

--- a/charts/exivity/templates/horizon/deployment.yaml
+++ b/charts/exivity/templates/horizon/deployment.yaml
@@ -33,6 +33,9 @@ spec:
             requests:
               cpu:    "25m"
               memory: "50Mi"
+          env:
+            - name: EXIVITY_BACKEND_LOG_LEVEL
+              value: "{{ .Values.logLevel.backend }}"
           securityContext:
             runAsUser:  1000
             runAsGroup: 1000

--- a/charts/exivity/templates/pigeon/deployment.yaml
+++ b/charts/exivity/templates/pigeon/deployment.yaml
@@ -67,6 +67,8 @@ spec:
               value: redis
             - name:  QUEUE_DRIVER
               value: redis
+            - name:  EXIVITY_BACKEND_LOG_LEVEL
+              value: "{{ .Values.logLevel.backend }}"
       {{- with .Values.service.pullSecrets }}
       imagePullSecrets:
         {{- range $name := .}}

--- a/charts/exivity/templates/proximity/cli.deployment.yaml
+++ b/charts/exivity/templates/proximity/cli.deployment.yaml
@@ -79,6 +79,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "exivity.fullname" $ -}}-jwt-secret
                   key:                                     jwt_secret
+            - name: EXIVITY_BACKEND_LOG_LEVEL
+              value: "{{ .Values.logLevel.backend }}"
       {{- with .Values.service.pullSecrets }}
       imagePullSecrets:
         {{- range $name := .}}

--- a/charts/exivity/templates/transcript/deployment.yaml
+++ b/charts/exivity/templates/transcript/deployment.yaml
@@ -74,6 +74,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "exivity.fullname" $ -}}-app-key
                   key:  app_key
+            - name: EXIVITY_BACKEND_LOG_LEVEL
+              value: "{{ .Values.logLevel.backend }}"
       {{- with .Values.service.pullSecrets }}
       imagePullSecrets:
         {{- range $name := .}}

--- a/charts/exivity/templates/use/deployment.yaml
+++ b/charts/exivity/templates/use/deployment.yaml
@@ -71,6 +71,8 @@ spec:
                   key:                                     app_key
             - name:  RUN_DELAY
               value: "10"
+            - name: EXIVITY_BACKEND_LOG_LEVEL
+              value: "{{ .Values.logLevel.backend }}"
       {{- with .Values.service.pullSecrets }}
       imagePullSecrets:
         {{- range $name := .}}

--- a/charts/exivity/values.yaml
+++ b/charts/exivity/values.yaml
@@ -148,3 +148,6 @@ service:
     repository: exivity/use
     tag:        ""
     pullPolicy: ""
+
+logLevel:
+  backend: "info"


### PR DESCRIPTION
The Go components (Merlin, Griffon, Chronos) were always started using the `info` log level. This could have been overridden only by using a flag (`-l debug` for example) when running the cmd to start them. 
This PR introduces an env variable used by the 3 components to set the log level at start. 

For the windows installation, the `EXIVITY_BACKEND_LOG_LEVEL` env variable needs to be set manually to the desired log level (`debug` most of the times). The components start by default with the `info` log level set. (NB! Don't forget to restart the services after setting a new value to this env variable)

Closes: NULL