### PR TITLE
feat: set replica count of services

### DIFF
--- a/charts/exivity/templates/chronos/deployment.yaml
+++ b/charts/exivity/templates/chronos/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/component: chronos
     {{- include "exivity.labels" $ | indent 4 }}
 spec:
+  replicas: {{ .Values.service.chronos.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/component: chronos

--- a/charts/exivity/templates/edify/deployment.yaml
+++ b/charts/exivity/templates/edify/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/component: edify
     {{- include "exivity.labels" $ | indent 4 }}
 spec:
+  replicas: {{ .Values.service.edify.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/component: edify

--- a/charts/exivity/templates/executor/deployment.yaml
+++ b/charts/exivity/templates/executor/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/component: executor
     {{- include "exivity.labels" $ | indent 4 }}
 spec:
+  replicas: {{ .Values.service.executor.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/component: executor

--- a/charts/exivity/templates/glass/deployment.yaml
+++ b/charts/exivity/templates/glass/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/component: glass
     {{- include "exivity.labels" $ | indent 4 }}
 spec:
+  replicas: {{ .Values.service.glass.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/component: glass

--- a/charts/exivity/templates/griffon/deployment.yaml
+++ b/charts/exivity/templates/griffon/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/component: griffon
     {{- include "exivity.labels" $ | indent 4 }}
 spec:
+  replicas: {{ .Values.service.griffon.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/component: griffon

--- a/charts/exivity/templates/horizon/deployment.yaml
+++ b/charts/exivity/templates/horizon/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/component: horizon
     {{- include "exivity.labels" $ | indent 4 }}
 spec:
+  replicas: {{ .Values.service.horizon.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/component: horizon

--- a/charts/exivity/templates/pigeon/deployment.yaml
+++ b/charts/exivity/templates/pigeon/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/component: pigeon
     {{- include "exivity.labels" $ | indent 4 }}
 spec:
+  replicas: {{ .Values.service.pigeon.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/component: pigeon

--- a/charts/exivity/templates/proximity/api.deployment.yaml
+++ b/charts/exivity/templates/proximity/api.deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/component: proximity-api
     {{- include "exivity.labels" $ | indent 4 }}
 spec:
+  replicas: {{ .Values.service.proximityApi.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/component: proximity-api

--- a/charts/exivity/templates/proximity/cli.deployment.yaml
+++ b/charts/exivity/templates/proximity/cli.deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/component: proximity-cli
     {{- include "exivity.labels" $ | indent 4 }}
 spec:
+  replicas: {{ .Values.service.proximityCli.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/component: proximity-cli

--- a/charts/exivity/templates/transcript/deployment.yaml
+++ b/charts/exivity/templates/transcript/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/component: transcript
     {{- include "exivity.labels" $ | indent 4 }}
 spec:
+  replicas: {{ .Values.service.transcript.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/component: transcript

--- a/charts/exivity/templates/use/deployment.yaml
+++ b/charts/exivity/templates/use/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/component: use
     {{- include "exivity.labels" $ | indent 4 }}
 spec:
+  replicas: {{ .Values.service.use.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/component: use

--- a/charts/exivity/values.yaml
+++ b/charts/exivity/values.yaml
@@ -83,6 +83,7 @@ service:
     pullPolicy:  ""
     servicePort: 80
     serviceType: ClusterIP
+    replicas:    1
   proximityApi:
     registry:    ""
     repository:  exivity/proximity-api
@@ -90,6 +91,7 @@ service:
     pullPolicy:  ""
     servicePort: 80
     serviceType: ClusterIP
+    replicas:    1
 
   # Back-end components
   chronos:
@@ -97,6 +99,7 @@ service:
     repository: exivity/chronos
     tag:        ""
     pullPolicy: ""
+    replicas:   1
   dbInit:
     registry:   ""
     repository: exivity/db
@@ -113,41 +116,49 @@ service:
     repository: exivity/edify
     tag:        ""
     pullPolicy: ""
+    replicas:   1
   executor:
     registry:   ""
     repository: exivity/executor
     tag:        ""
     pullPolicy: ""
+    replicas:   1
   griffon:
     registry:   ""
     repository: exivity/griffon
     tag:        ""
     pullPolicy: ""
+    replicas:   1
   horizon:
     registry:   ""
     repository: exivity/horizon
     tag:        ""
     pullPolicy: ""
+    replicas:   1
   pigeon:
     registry:   ""
     repository: exivity/pigeon
     tag:        ""
     pullPolicy: ""
+    replicas:   1
   proximityCli:
     registry:   ""
     repository: exivity/proximity-cli
     tag:        ""
     pullPolicy: ""
+    replicas:   1
   transcript:
     registry:   ""
     repository: exivity/transcript
     tag:        ""
     pullPolicy: ""
+    replicas:   1
   use:
     registry:   ""
     repository: exivity/use
     tag:        ""
     pullPolicy: ""
+    replicas:   1
 
 logLevel:
   backend: "info"


### PR DESCRIPTION
This PR allows the setting of replica count for individual services, but it must be noted that for some services, this is not actually supported yet. Therefore, this is a draft PR for now till this has been resolved or it has been mapped out in detail which services can have multiple replicas and which can't.