### PR TITLE
feat: add easy way to enable & set autoscaler options to deployments

### DIFF
--- a/charts/exivity/templates/_autoscaler.tpl
+++ b/charts/exivity/templates/_autoscaler.tpl
@@ -41,8 +41,16 @@ spec:
     resource:
       name: memory
       target:
-        type: Utilization
+        type: AverageValue
         averageUtilization: {{ (index .Values.service .name).autoscaling.averageMemoryValue }}
+  {{- end}}
+  {{- if (index .Values.service .name).autoscaling.averageCustomValue }}
+  - type: {{ (index .Values.service .name).autoscaling.customType | default "Resource" }}
+    resource:
+      name: {{ (index .Values.service .name).autoscaling.customResource }}
+      target:
+        type: AverageValue
+        averageUtilization: {{ (index .Values.service .name).autoscaling.averageCustomValue }}
   {{- end}}
   {{- if and (not (index .Values.service .name).autoscaling.averageMemoryValue) (not (index .Values.service .name).autoscaling.averageMemoryUtilization) (not (index .Values.service .name).autoscaling.averageCPUUtilization) }}
     []

--- a/charts/exivity/templates/_autoscaler.tpl
+++ b/charts/exivity/templates/_autoscaler.tpl
@@ -1,0 +1,51 @@
+{{/*
+# Generate an autoscaler for the service.
+# Pass the service autoscaler options as the parameter
+#
+# E.g.
+# {{- include "exivity.autoscaler" (set $ "name" "glass") }}
+*/}}
+{{- define "exivity.autoscaler" }}
+{{- if (index .Values.service .name).autoscaling }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ printf "%s-autoscaler-%s" ( include "exivity.fullname" $ ) (kebabcase .name) }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ printf "%s-%s" ( include "exivity.fullname" $ ) (kebabcase .name) }}
+  minReplicas: {{ (index .Values.service .name).autoscaling.minReplicas | default 1 }}
+  maxReplicas: {{ (index .Values.service .name).autoscaling.maxReplicas | default 5 }}
+  metrics:
+  {{- if (index .Values.service .name).autoscaling.averageCPUUtilization }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ (index .Values.service .name).autoscaling.averageCPUUtilization }}
+  {{- end}}
+  {{- if (index .Values.service .name).autoscaling.averageMemoryUtilization }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ (index .Values.service .name).autoscaling.averageMemoryUtilization }}
+  {{- end}}
+  {{- if (index .Values.service .name).autoscaling.averageMemoryValue }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ (index .Values.service .name).autoscaling.averageMemoryValue }}
+  {{- end}}
+  {{- if and (not (index .Values.service .name).autoscaling.averageMemoryValue) (not (index .Values.service .name).autoscaling.averageMemoryUtilization) (not (index .Values.service .name).autoscaling.averageCPUUtilization) }}
+    []
+  {{- end}}
+{{- end }}
+{{- end }}

--- a/charts/exivity/templates/chronos/deployment.yaml
+++ b/charts/exivity/templates/chronos/deployment.yaml
@@ -65,3 +65,4 @@ spec:
         {{ $key }}: {{ $val }}
         {{- end }}
       {{- end }}
+{{ include "exivity.autoscaler" (set $ "name" "chronos") }}

--- a/charts/exivity/templates/edify/deployment.yaml
+++ b/charts/exivity/templates/edify/deployment.yaml
@@ -77,3 +77,4 @@ spec:
         {{ $key }}: {{ $val }}
         {{- end }}
       {{- end }}
+{{ include "exivity.autoscaler" (set $ "name" "edify") }}

--- a/charts/exivity/templates/executor/deployment.yaml
+++ b/charts/exivity/templates/executor/deployment.yaml
@@ -85,3 +85,4 @@ spec:
         {{ $key }}: {{ $val }}
         {{- end }}
       {{- end }}
+{{ include "exivity.autoscaler" (set $ "name" "executor") }}

--- a/charts/exivity/templates/glass/deployment.yaml
+++ b/charts/exivity/templates/glass/deployment.yaml
@@ -54,3 +54,4 @@ spec:
         {{ $key }}: {{ $val }}
         {{- end }}
       {{- end }}
+{{ include "exivity.autoscaler" (set $ "name" "glass") }}

--- a/charts/exivity/templates/griffon/deployment.yaml
+++ b/charts/exivity/templates/griffon/deployment.yaml
@@ -65,3 +65,4 @@ spec:
         {{ $key }}: {{ $val }}
         {{- end }}
       {{- end }}
+{{ include "exivity.autoscaler" (set $ "name" "griffon") }}

--- a/charts/exivity/templates/horizon/deployment.yaml
+++ b/charts/exivity/templates/horizon/deployment.yaml
@@ -62,3 +62,4 @@ spec:
         {{ $key }}: {{ $val }}
         {{- end }}
       {{- end }}
+{{ include "exivity.autoscaler" (set $ "name" "horizon") }}

--- a/charts/exivity/templates/pigeon/deployment.yaml
+++ b/charts/exivity/templates/pigeon/deployment.yaml
@@ -85,3 +85,4 @@ spec:
         {{ $key }}: {{ $val }}
         {{- end }}
       {{- end }}
+{{ include "exivity.autoscaler" (set $ "name" "pigeon") }}

--- a/charts/exivity/templates/proximity/api.deployment.yaml
+++ b/charts/exivity/templates/proximity/api.deployment.yaml
@@ -161,3 +161,4 @@ spec:
         {{ $key }}: {{ $val }}
         {{- end }}
       {{- end }}
+{{ include "exivity.autoscaler" (set $ "name" "proximityApi") }}

--- a/charts/exivity/templates/proximity/cli.deployment.yaml
+++ b/charts/exivity/templates/proximity/cli.deployment.yaml
@@ -97,3 +97,4 @@ spec:
         {{ $key }}: {{ $val }}
         {{- end }}
       {{- end }}
+{{ include "exivity.autoscaler" (set $ "name" "proximityCli") }}

--- a/charts/exivity/templates/transcript/deployment.yaml
+++ b/charts/exivity/templates/transcript/deployment.yaml
@@ -92,3 +92,4 @@ spec:
         {{ $key }}: {{ $val }}
         {{- end }}
       {{- end }}
+{{ include "exivity.autoscaler" (set $ "name" "transcript") }}

--- a/charts/exivity/templates/use/deployment.yaml
+++ b/charts/exivity/templates/use/deployment.yaml
@@ -89,3 +89,4 @@ spec:
         {{ $key }}: {{ $val }}
         {{- end }}
       {{- end }}
+{{ include "exivity.autoscaler" (set $ "name" "use") }}

--- a/charts/exivity/values.yaml
+++ b/charts/exivity/values.yaml
@@ -86,6 +86,7 @@ service:
     replicas:    1
     nodeName: ""
     nodeSelector: {}
+    autoscaling: {}
     
   proximityApi:
     registry:    ""
@@ -97,6 +98,9 @@ service:
     replicas:    1
     nodeName: ""
     nodeSelector: {}
+    autoscaling:
+      averageCPUUtilization: 70
+      averageMemoryUtilization: 70
 
   # Back-end components
   chronos:
@@ -107,6 +111,7 @@ service:
     replicas:   1
     nodeName: ""
     nodeSelector: {}
+    autoscaling: {}
 
   dbInit:
     registry:   ""
@@ -115,6 +120,7 @@ service:
     pullPolicy: ""
     nodeName: ""
     nodeSelector: {}
+    autoscaling: {}
     
   dummyData:
     enabled:    false
@@ -124,6 +130,7 @@ service:
     pullPolicy: ""
     nodeName: ""
     nodeSelector: {}
+    autoscaling: {}
     
   edify:
     registry:   ""
@@ -133,6 +140,7 @@ service:
     replicas:   1
     nodeName: ""
     nodeSelector: {}
+    autoscaling: {}
 
   executor:
     registry:   ""
@@ -142,6 +150,7 @@ service:
     replicas:   1
     nodeName: ""
     nodeSelector: {}
+    autoscaling: {}
 
   griffon:
     registry:   ""
@@ -151,6 +160,7 @@ service:
     replicas:   1
     nodeName: ""
     nodeSelector: {}
+    autoscaling: {}
     
   horizon:
     registry:   ""
@@ -160,6 +170,7 @@ service:
     replicas:   1
     nodeName: ""
     nodeSelector: {}
+    autoscaling: {}
 
   pigeon:
     registry:   ""
@@ -169,6 +180,7 @@ service:
     replicas:   1
     nodeName: ""
     nodeSelector: {}
+    autoscaling: {}
 
   proximityCli:
     registry:   ""
@@ -178,6 +190,7 @@ service:
     replicas:   1
     nodeName: ""
     nodeSelector: {}
+    autoscaling: {}
 
   transcript:
     registry:   ""
@@ -187,6 +200,7 @@ service:
     replicas:   1
     nodeName: ""
     nodeSelector: {}
+    autoscaling: {}
 
   use:
     registry:   ""
@@ -196,6 +210,7 @@ service:
     replicas:   1
     nodeName: ""
     nodeSelector: {}
+    autoscaling: {}
 
 logLevel:
   backend: "info"


### PR DESCRIPTION
This adds a template that gets included in the deployment files, that adds, if set, a HorizontalPodAutoscaler to the deployment.
This currently has support for resource trackers for cpu average utilization, memory average utilization and value, and a custom average value.