### PR TITLE
feat: liveness probe to detect stale file handles

### DIFF
--- a/charts/exivity/templates/_liveness.tpl
+++ b/charts/exivity/templates/_liveness.tpl
@@ -1,0 +1,12 @@
+{{- define "exivity.nfs-liveness" }}
+livenessProbe:
+  exec:
+    command:
+      - sh
+      - -c
+      - list=$(df 2>&1 | grep -i 'Stale file handle'); [ ${#list} -ne 0 ] && exit 1 || exit 0
+  initialDelaySeconds: 10
+  periodSeconds: 20
+  timeoutSeconds: 2
+  failureThreshold: 2
+{{- end }}

--- a/charts/exivity/templates/chronos/deployment.yaml
+++ b/charts/exivity/templates/chronos/deployment.yaml
@@ -50,6 +50,7 @@ spec:
               mountPath: /exivity/home/system
             - name:      log
               mountPath: /exivity/home/log/chronos
+          {{- include "exivity.nfs-liveness" $ | indent 10}}
       {{- with .Values.service.pullSecrets }}
       imagePullSecrets:
         {{- range $name := .}}

--- a/charts/exivity/templates/edify/deployment.yaml
+++ b/charts/exivity/templates/edify/deployment.yaml
@@ -62,6 +62,7 @@ spec:
               mountPath: /exivity/home/log/merlin
             - name:      report
               mountPath: /exivity/home/system/report
+          {{- include "exivity.nfs-liveness" $ | indent 10}}
       {{- with .Values.service.pullSecrets }}
       imagePullSecrets:
         {{- range $name := .}}

--- a/charts/exivity/templates/executor/deployment.yaml
+++ b/charts/exivity/templates/executor/deployment.yaml
@@ -70,6 +70,7 @@ spec:
               mountPath: /exivity/home/system/report
             - name:      log
               mountPath: /exivity/home/log/merlin
+          {{- include "exivity.nfs-liveness" $ | indent 10}}
       {{- with .Values.service.pullSecrets }}
       imagePullSecrets:
         {{- range $name := .}}

--- a/charts/exivity/templates/glass/deployment.yaml
+++ b/charts/exivity/templates/glass/deployment.yaml
@@ -39,6 +39,7 @@ spec:
           volumeMounts:
             - name:      log
               mountPath: /exivity/home/log/glass
+          {{- include "exivity.nfs-liveness" $ | indent 10}}
       {{- with .Values.service.pullSecrets }}
       imagePullSecrets:
         {{- range $name := .}}

--- a/charts/exivity/templates/griffon/deployment.yaml
+++ b/charts/exivity/templates/griffon/deployment.yaml
@@ -50,6 +50,7 @@ spec:
               mountPath: /exivity/home/system/config
             - name:      log
               mountPath: /exivity/home/log/griffon
+          {{- include "exivity.nfs-liveness" $ | indent 10}}
       {{- with .Values.service.pullSecrets }}
       imagePullSecrets:
         {{- range $name := .}}

--- a/charts/exivity/templates/horizon/deployment.yaml
+++ b/charts/exivity/templates/horizon/deployment.yaml
@@ -47,6 +47,7 @@ spec:
               mountPath: /exivity/home/log/horizon
             - name:      log
               mountPath: /exivity/home/log/merlin
+          {{- include "exivity.nfs-liveness" $ | indent 10}}
       {{- with .Values.service.pullSecrets }}
       imagePullSecrets:
         {{- range $name := .}}

--- a/charts/exivity/templates/pigeon/deployment.yaml
+++ b/charts/exivity/templates/pigeon/deployment.yaml
@@ -70,6 +70,7 @@ spec:
               value: redis
             - name:  EXIVITY_BACKEND_LOG_LEVEL
               value: "{{ .Values.logLevel.backend }}"
+          {{- include "exivity.nfs-liveness" $ | indent 10}}
       {{- with .Values.service.pullSecrets }}
       imagePullSecrets:
         {{- range $name := .}}

--- a/charts/exivity/templates/proximity/api.deployment.yaml
+++ b/charts/exivity/templates/proximity/api.deployment.yaml
@@ -142,6 +142,7 @@ spec:
               value: file
             - name:  QUEUE_CONNECTION
               value: sync
+          {{- include "exivity.nfs-liveness" $ | indent 10}}
         {{- if .Values.ingress.trustedProxy }}
             - name: TRUSTED_PROXY
               value: {{ printf "%s" (.Values.ingress.trustedProxy) | quote }}

--- a/charts/exivity/templates/proximity/cli.deployment.yaml
+++ b/charts/exivity/templates/proximity/cli.deployment.yaml
@@ -82,6 +82,7 @@ spec:
                   key:                                     jwt_secret
             - name: EXIVITY_BACKEND_LOG_LEVEL
               value: "{{ .Values.logLevel.backend }}"
+          {{- include "exivity.nfs-liveness" $ | indent 10}}
       {{- with .Values.service.pullSecrets }}
       imagePullSecrets:
         {{- range $name := .}}

--- a/charts/exivity/templates/transcript/deployment.yaml
+++ b/charts/exivity/templates/transcript/deployment.yaml
@@ -77,6 +77,7 @@ spec:
                   key:  app_key
             - name: EXIVITY_BACKEND_LOG_LEVEL
               value: "{{ .Values.logLevel.backend }}"
+          {{- include "exivity.nfs-liveness" $ | indent 10}}
       {{- with .Values.service.pullSecrets }}
       imagePullSecrets:
         {{- range $name := .}}

--- a/charts/exivity/templates/use/deployment.yaml
+++ b/charts/exivity/templates/use/deployment.yaml
@@ -74,6 +74,7 @@ spec:
               value: "10"
             - name: EXIVITY_BACKEND_LOG_LEVEL
               value: "{{ .Values.logLevel.backend }}"
+          {{- include "exivity.nfs-liveness" $ | indent 10}}
       {{- with .Values.service.pullSecrets }}
       imagePullSecrets:
         {{- range $name := .}}


### PR DESCRIPTION
This probe tests every 20 seconds if any mount gives a stale file handle error. If it does, or if the probe takes longer than 2 seconds (as it's trying and failing to reach nfs), the probe fails. 2 failures will cause the pod to be restarted.