### PR TITLE
chore: increase ProximityAPI default request resources

### DIFF
--- a/charts/exivity/values.yaml
+++ b/charts/exivity/values.yaml
@@ -110,7 +110,7 @@ service:
     resources:
       requests:
         cpu:    "25m"
-        memory: "50Mi"
+        memory: "384Mi"
 
   # Back-end components
   chronos:


### PR DESCRIPTION
To ensure that ProximityAPI runs on a node with enough free resource, to default values needs to be increase for the memory resources.