### PR TITLE
fix: add config volume to pigeon deployment

### DIFF
--- a/charts/exivity/templates/pigeon/deployment.yaml
+++ b/charts/exivity/templates/pigeon/deployment.yaml
@@ -32,6 +32,9 @@ spec:
         - name: import
           persistentVolumeClaim:
             claimName: {{ include "exivity.fullname" $ -}}-import
+        - name: config-volume
+          persistentVolumeClaim:
+            claimName: {{ include "exivity.fullname" $ -}}-etl-config
       containers:
         - name:            pigeon
           image: {{ include "exivity.image" (set $ "name" "pigeon") }}
@@ -52,6 +55,8 @@ spec:
               mountPath: /exivity/home/import
             - name:      exported
               mountPath: /exivity/home/exported
+            - name:      config-volume
+              mountPath: /exivity/home/system/config
           env:
             - name: EXIVITY_APP_KEY
               valueFrom:


### PR DESCRIPTION
Pigeon did not have access to the `.dat` configuration files, so it couldn't start correctly. This was also causing Laravel to save the emergency log instead of the good one, and Merlin was not able to get the logfile contents to dump them on the stdout. It was a chain of events.

Closes: EXVT-5675