### PR TITLE
feat: Add PHP memory limit configuration for proximity API

### DIFF
--- a/charts/exivity/templates/proximity/api.deployment.yaml
+++ b/charts/exivity/templates/proximity/api.deployment.yaml
@@ -146,6 +146,10 @@ spec:
             - name: TRUSTED_PROXY
               value: {{ printf "%s" (.Values.ingress.trustedProxy) | quote }}
         {{- end }}
+        {{- if .Values.service.proximityApi.phpMemoryLimit }}
+            - name: PHP_MEMORY_LIMIT
+              value: {{ printf "%s" (.Values.service.proximityApi.phpMemoryLimit) | quote }}
+        {{- end }}
           {{- include "exivity.nfs-liveness" $ | indent 10}}
       {{- with .Values.service.pullSecrets }}
       imagePullSecrets:

--- a/charts/exivity/values.yaml
+++ b/charts/exivity/values.yaml
@@ -116,12 +116,15 @@ service:
       requests:
         cpu:    "25m"
         memory: "50Mi"
-    
+
   proximityApi:
     registry:    ""
     repository:  exivity/proximity-api
     tag:         ""
     pullPolicy:  ""
+    # set the PHP memory limit per requests
+    # https://www.php.net/manual/en/ini.core.php#ini.memory-limit
+    phpMemoryLimit: "3G"
     servicePort: 80
     serviceType: ClusterIP
     replicas:    1
@@ -208,7 +211,7 @@ service:
       requests:
         cpu:    "25m"
         memory: "50Mi"
-    
+
   horizon:
     registry:   ""
     repository: exivity/horizon


### PR DESCRIPTION
This pull request adds a PHP memory limit configuration for the proximity API service. The PHP memory limit is set to 3G to ensure sufficient memory allocation for the service.

Close: [EXVT-5702](https://exivity.atlassian.net/browse/EXVT-5702)

[EXVT-5702]: https://exivity.atlassian.net/browse/EXVT-5702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ