### PR TITLE
chore: set volumeMounts with same names in correct order

### DIFF
--- a/charts/exivity/templates/pigeon/deployment.yaml
+++ b/charts/exivity/templates/pigeon/deployment.yaml
@@ -48,9 +48,9 @@ spec:
             - name:      config
               mountPath: /exivity/home/system
             - name:      log
-              mountPath: /exivity/home/log/merlin
-            - name:      log
               mountPath: /exivity/home/log/pigeon
+            - name:      log
+              mountPath: /exivity/home/log/merlin
             - name:      import
               mountPath: /exivity/home/import
             - name:      exported

--- a/charts/exivity/templates/proximity/cli.deployment.yaml
+++ b/charts/exivity/templates/proximity/cli.deployment.yaml
@@ -60,9 +60,9 @@ spec:
             - name:      extracted
               mountPath: /exivity/home/system/extracted
             - name:      log
-              mountPath: /exivity/home/log/merlin
-            - name:      log
               mountPath: /exivity/home/log/proximity
+            - name:      log
+              mountPath: /exivity/home/log/merlin
             - name:      import
               mountPath: /exivity/home/import
             - name:      report

--- a/charts/exivity/templates/use/deployment.yaml
+++ b/charts/exivity/templates/use/deployment.yaml
@@ -59,9 +59,9 @@ spec:
             - name:      import
               mountPath: /exivity/home/import
             - name:      log
-              mountPath: /exivity/home/log/merlin
-            - name:      log
               mountPath: /exivity/home/log/use
+            - name:      log
+              mountPath: /exivity/home/log/merlin
           env:
             - name: EXIVITY_APP_KEY
               valueFrom:


### PR DESCRIPTION
If two volumeMounts have the same name, the first one defined is taking precedence. For example, in 
Pigeon's deployment, defining `/home/log/merlin` before `/home/log/pigeon` causes pigeon logfile to not exist. Defining them in reversed order fixes the issue and both pigeon and merlin logfiles exist.

Closes: NULL