### PR TITLE
chore: add support for CA certificates in use deployment

### DIFF
--- a/charts/exivity/templates/use/certs.yaml
+++ b/charts/exivity/templates/use/certs.yaml
@@ -1,0 +1,11 @@
+{{if gt (len .Values.service.use.caCertificates) 0 -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "exivity.fullname" $ -}}-use-certificates
+type: Opaque
+data:
+  {{- range $key, $value := .Values.service.use.caCertificates }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/exivity/templates/use/deployment.yaml
+++ b/charts/exivity/templates/use/deployment.yaml
@@ -38,6 +38,31 @@ spec:
         - name: log
           persistentVolumeClaim:
             claimName: {{ include "exivity.fullname" $ -}}-use-log
+      {{- if gt (len .Values.service.use.caCertificates) 0 }}
+        - name: cert-volume
+          emptyDir: {}
+        - name: ca-certificates
+          secret:
+            secretName: {{ include "exivity.fullname" $ -}}-use-certificates
+      initContainers:
+        - name: install-ca-cert
+          image: {{ include "exivity.image" (set $ "name" "use") }}
+          command: ["sh", "-c", "update-ca-certificates && cp -r /etc/ssl/certs/* /certs/"]
+          volumeMounts:
+            - name: cert-volume
+              mountPath: /certs
+            {{- range $key, $value := .Values.service.use.caCertificates }}
+            - name: ca-certificates
+              mountPath: /usr/local/share/ca-certificates/{{$key}}
+              subPath: {{$key}}
+              readOnly: true
+            {{- end }}
+          resources:
+            {{- toYaml .Values.service.use.initContainers.installCACert.resources | nindent 12 }}
+            limits:
+              cpu: "100m"
+              memory: "50Mi"
+      {{- end }}
       containers:
         - name:            use
           image: {{ include "exivity.image" (set $ "name" "use") }}
@@ -62,6 +87,10 @@ spec:
               mountPath: /exivity/home/log/use
             - name:      log
               mountPath: /exivity/home/log/merlin
+            {{- if gt (len .Values.service.use.caCertificates) 0 }}
+            - name: cert-volume
+              mountPath: /etc/ssl/certs
+            {{- end }}
           env:
             - name: EXIVITY_APP_KEY
               valueFrom:

--- a/charts/exivity/values.yaml
+++ b/charts/exivity/values.yaml
@@ -283,19 +283,19 @@ service:
           requests:
             cpu:    "25m"
             memory: "50Mi"
-    # caCertificates: In this section, the CA certificates to be used by the service can be specified.
-    # Each entry should be a key-value pair where the key is a descriptive name for the certificate (e.g., 'rootCA', 'intermediateCA')
-    # and the value is the certificate itself.
-    # As many certificates as needed can be added.
-    # 'rootCA.pem' and 'intermediateCA.pem' should be replaced with the names of the actual certificates.
+    # In the following caCertificates section, you can specify the Certificate Authority (CA) certificates that your service uses. 
+    # Each certificate should be listed as a key-value pair, where the key is a name you assign to the certificate for identification 
+    # (like 'rootCA' or 'intermediateCA'), and the value is the actual certificate. You can include as many certificates as necessary 
+    # by replacing the placeholder names like 'rootCA.pem' and 'intermediateCA.pem' with the actual file names of your certificates.
     #
     # Instructions for fetching CA certificates using OpenSSL:
+    # --------------------------------------------------------
     # To fetch and add CA certificates to this configuration, follow the steps below using OpenSSL:
     # 1. Open a terminal on your system.
     # 2. Use the following OpenSSL command to connect to the desired HTTPS server and retrieve the certificate:
     #      echo | openssl s_client -servername <your-server-name> -connect <your-server-name>:443 -showcerts | openssl x509 -outform PEM > your_certificate_name.pem
     #    Replace `<your-server-name>` with the actual server name and `your_certificate_name.pem` with the desired file name for your certificate.
-    # 3. Once you have the certificate, you can add it to the caCertificates section above by replacing the existing placeholders.
+    # 3. Once you have the certificate, you can add it to the caCertificates section below by replacing the existing placeholders.
     #    Ensure the entire certificate text including the "BEGIN CERTIFICATE" and "END CERTIFICATE" lines is correctly pasted under the appropriate key.
     caCertificates:
       # rootCA.pem: |

--- a/charts/exivity/values.yaml
+++ b/charts/exivity/values.yaml
@@ -276,6 +276,36 @@ service:
       requests:
         cpu:    "25m"
         memory: "50Mi"
+    # Configuration for the init container that installs CA certificates
+    initContainers:
+      installCACert:
+        resources:
+          requests:
+            cpu:    "25m"
+            memory: "50Mi"
+    # caCertificates: In this section, the CA certificates to be used by the service can be specified.
+    # Each entry should be a key-value pair where the key is a descriptive name for the certificate (e.g., 'rootCA', 'intermediateCA')
+    # and the value is the certificate itself.
+    # As many certificates as needed can be added.
+    # 'rootCA.pem' and 'intermediateCA.pem' should be replaced with the names of the actual certificates.
+    #
+    # Instructions for fetching CA certificates using OpenSSL:
+    # To fetch and add CA certificates to this configuration, follow the steps below using OpenSSL:
+    # 1. Open a terminal on your system.
+    # 2. Use the following OpenSSL command to connect to the desired HTTPS server and retrieve the certificate:
+    #      echo | openssl s_client -servername <your-server-name> -connect <your-server-name>:443 -showcerts | openssl x509 -outform PEM > your_certificate_name.pem
+    #    Replace `<your-server-name>` with the actual server name and `your_certificate_name.pem` with the desired file name for your certificate.
+    # 3. Once you have the certificate, you can add it to the caCertificates section above by replacing the existing placeholders.
+    #    Ensure the entire certificate text including the "BEGIN CERTIFICATE" and "END CERTIFICATE" lines is correctly pasted under the appropriate key.
+    caCertificates:
+      # rootCA.pem: |
+      #   -----BEGIN CERTIFICATE-----
+      #   MIIFPDCCB....
+      #   -----END CERTIFICATE-----
+      # intermediateCA.pem: |
+      #   -----BEGIN CERTIFICATE-----
+      #   MIIFPDCCB....
+      #   -----END CERTIFICATE-----
 
 logLevel:
   backend: "info"


### PR DESCRIPTION
This pull request adds support for CA certificates in the use deployment. It includes changes to the deployment configuration file to mount the certificates and an init container to install the certificates. The certificates can be specified in the `caCertificates` section of the configuration file.

Close: https://exivity.atlassian.net/browse/ECS-898