### PR TITLE
chore: Reduce initial delay for liveness and readiness probes in values.yaml

### DIFF
--- a/charts/exivity/values.yaml
+++ b/charts/exivity/values.yaml
@@ -332,12 +332,12 @@ logLevel:
 probes:
   livenessProbe:
     enabled: true
-    initialDelaySeconds: 30
+    initialDelaySeconds: 3
     periodSeconds: 30
     failureThreshold: 120
   readinessProbe:
     enabled: true
-    initialDelaySeconds: 30
+    initialDelaySeconds: 3
     periodSeconds: 30
     failureThreshold: 60
 


### PR DESCRIPTION
This PR reduces the initial delay for both liveness and readiness probes from 30 seconds to 3 seconds in the `values.yaml` file, improving the responsiveness of the application during startup.