### PR TITLE
chore: Add service tag to deployment in Makefile for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ deploy-exivity-chart:
         --set storage.storageClass=$(NFS_STORAGE_CLASS) \
         --set ingress.host=$(INGRESS_HOSTNAME) \
         --set ingress.ingressClassName="nginx" \
-        --set logLevel.backend="debug"
+        --set logLevel.backend="debug" \
+        --set service.tag="daily"
 
 # Deploy NFS Helm chart to Minikube
 # This is a dependency for the exivity Helm chart


### PR DESCRIPTION
This PR introduces a new service tag to the deployment configuration in the Makefile, enhancing the integration-test process by using the latest images.