### PR TITLE
fix: Set heartbeatPeriod to 0 for chronos, griffon, and merlin

### DIFF
--- a/charts/exivity/templates/_config.tpl
+++ b/charts/exivity/templates/_config.tpl
@@ -45,17 +45,17 @@ data:
           "redialPeriod": 5
       },
       "chronos": {
-        "heartbeatPeriod": 5,
+        "heartbeatPeriod": 0,
         "TTL": 60
       },
       "griffon": {
-        "heartbeatPeriod": 5,
+        "heartbeatPeriod": 0,
         "TTL": 10
       {{ if $.data.appname }}
       },
       "merlin": {
         "reservedCPU": 0,
-        "heartbeatPeriod": 5,
+        "heartbeatPeriod": 0,
         "programs": {
           "{{ $.data.appname }}": {
             "component": "{{ $.data.appname }}",


### PR DESCRIPTION
This PR updates the configuration for chronos, griffon, and merlin by setting the `heartbeatPeriod` to 0. This change aims to optimize performance by reducing unnecessary heartbeat signals. A heardbeat is only needed for a Windows deployment and leads under Kubernetes to unroutable messages.