### PR TITLE
Add `fsGroup` to securityContext for Griffon and Proximity

### DIFF
--- a/charts/exivity/templates/griffon/deployment.yaml
+++ b/charts/exivity/templates/griffon/deployment.yaml
@@ -19,6 +19,10 @@ spec:
       annotations:
         checksum/{{- include "exivity.fullname" $ -}}-config-shared: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
+      securityContext:
+        fsGroup: 1000
+        runAsUser:  1000
+        runAsGroup: 1000
       volumes:
         - name: config-file
           configMap:

--- a/charts/exivity/templates/proximity/api.deployment.yaml
+++ b/charts/exivity/templates/proximity/api.deployment.yaml
@@ -22,6 +22,10 @@ spec:
         checksum/{{- include "exivity.fullname" $ -}}-licence-key: {{ include (print $.Template.BasePath "/proximity/api.secret.yaml") . | sha256sum }}
         checksum/{{- include "exivity.fullname" $ -}}-lock: {{ include (print $.Template.BasePath "/proximity/api.configmap.yaml") . | sha256sum }}
     spec:
+      securityContext:
+        fsGroup: 1000
+        runAsUser:  1000
+        runAsGroup: 1000
       volumes:
         - name: projected
           projected:

--- a/charts/exivity/templates/proximity/cli.deployment.yaml
+++ b/charts/exivity/templates/proximity/cli.deployment.yaml
@@ -19,6 +19,10 @@ spec:
       annotations:
         checksum/{{- include "exivity.fullname" $ -}}-config-proximity-cli: {{ include (print $.Template.BasePath "/proximity/cli.configmap.yaml") . | sha256sum }}
     spec:
+      securityContext:
+        fsGroup: 1000
+        runAsUser:  1000
+        runAsGroup: 1000
       volumes:
         - name: config-file
           configMap:


### PR DESCRIPTION
This forces Kubernetes to change the ownership of attached volumes so that the pods can access them. This sometimes did not happen when attaching volumes created by some CSIs like Longhorn. 

Before this change, the attached volumes would be owned by the root user and group. This would cause the `proximity-cli` and `proximity-api` pods to enter a `CrashBackoffLoop` with errors in the logs of not being able to access `/exivity/home/log/merlin/merlin.log`. The `griffon` pod would silently fail by never entering the ready state but without ever showing any errors in the logs.

I believe this is due to how Kubernetes handles changing volume ownership when attaching to a pod: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#delegating-volume-permission-and-ownership-change-to-csi-driver. Kubernetes normally handles ownership changes itself, but it will delegate the responsibility to the CSI driver if the driver reports that it has the requested capability. By setting the `fsGroup` option in the `securityContext`, we instruct the CSI how to change the ownership of the volume before attaching it.