### PR TITLE
chore: Add Helm hook annotations to job templates

### DIFF
--- a/charts/exivity/templates/dummy-data/job.yaml
+++ b/charts/exivity/templates/dummy-data/job.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: dummy-data
     {{- include "exivity.labels" $ | indent 4 }}
   annotations:
-    "helm.sh/hook": pre-upgrade,pre-install
+    "helm.sh/hook": post-upgrade,post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
     helm.sh/hook-weight: "20"
 spec:

--- a/charts/exivity/templates/dummy-data/job.yaml
+++ b/charts/exivity/templates/dummy-data/job.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     app.kubernetes.io/component: dummy-data
     {{- include "exivity.labels" $ | indent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade,pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+    helm.sh/hook-weight: "20"
 spec:
   completions:             1
   ttlSecondsAfterFinished: 300

--- a/charts/exivity/templates/migration/job.yaml
+++ b/charts/exivity/templates/migration/job.yaml
@@ -18,34 +18,6 @@ spec:
         app.kubernetes.io/component: migration
         {{- include "exivity.labels" $ | indent 8 }}
     spec:
-      initContainers:
-        - name: wait-for-server
-          image: {{ include "exivity.image" (set $ "name" "dbInit") }}
-          imagePullPolicy: {{ .Values.service.dbInit.pullPolicy | default .Values.service.pullPolicy | default "IfNotPresent" }}
-          command:
-            - "/wait.sh"
-          args:
-            - "--host"
-            - "$(PG_HOST)"
-            - "--port"
-            - "$(PG_PORT)"
-            - "--dbname"
-            - "$(PG_DATABASE)"
-            - "--username"
-            - "$(PG_USER)"
-          env:
-            - name: PG_HOST
-              value: {{ $.Values.postgresql.host | default (printf "%s-postgresql" (include "exivity.fullname" $ )) | quote }}
-            - name: PG_PORT
-              value: {{ $.Values.postgresql.port | default 5432 | quote}}
-            - name: PG_DATABASE
-              value: {{ $.Values.postgresql.global.postgresql.auth.database | quote }}
-            - name: PG_USER
-              value: {{ $.Values.postgresql.global.postgresql.auth.username | quote }}
-            - name: PG_SSLMODE
-              value: {{ $.Values.postgresql.sslmode | default "disable" | quote  }}
-          resources:
-            {{- toYaml .Values.service.dbInit.waitForServer.resources | nindent 12 }}
       containers:
         - name: migration
           image: {{ include "exivity.image" (set $ "name" "dbInit") }}

--- a/charts/exivity/templates/migration/job.yaml
+++ b/charts/exivity/templates/migration/job.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: migration
     {{- include "exivity.labels" $ | indent 4 }}
   annotations:
-    "helm.sh/hook": pre-upgrade,pre-install
+    "helm.sh/hook": post-upgrade,post-install
     "helm.sh/hook-delete-policy": hook-succeeded
     helm.sh/hook-weight: "0"
 spec:

--- a/charts/exivity/templates/migration/job.yaml
+++ b/charts/exivity/templates/migration/job.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/component: migration
     {{- include "exivity.labels" $ | indent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade,pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+    helm.sh/hook-weight: "0"
 spec:
   completions:             1
   ttlSecondsAfterFinished: 300


### PR DESCRIPTION
Introduce Helm hook annotations to the dummy-data and migration job templates to manage job execution during upgrades and installations.