### PR TITLE
chore: Update PersistentVolumeClaims access mode to ReadWriteMany

### DIFF
--- a/charts/exivity/templates/proximity/api.persistentvolumeclaim.yaml
+++ b/charts/exivity/templates/proximity/api.persistentvolumeclaim.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "exivity.labels" $ | indent 4 }}
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
       storage: 1Gi

--- a/charts/exivity/templates/proximity/cli.persistentvolumeclaim.yaml
+++ b/charts/exivity/templates/proximity/cli.persistentvolumeclaim.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "exivity.labels" $ | indent 4 }}
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
       storage: 1Gi


### PR DESCRIPTION
Change the access mode for proximity PersistentVolumeClaims from ReadWriteOnce to ReadWriteMany to allow multiple nodes to read and write to the volume simultaneously.