### PR TITLE
chore: Update PersistentVolumeClaims to use dynamic storage sizes from values.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@
 NFS_STORAGE_CLASS := nfs-client
 NFS_CHART_VERSION := 1.8.0
 
-PVC_DEFAULT_STORAGE_SIZE := 200Mi
-
 INGRESS_HOSTNAME := exivity.local
 
 HELM_TIMEOUT := 10m
@@ -26,23 +24,6 @@ deploy-exivity-chart:
         --debug \
         --timeout $(HELM_TIMEOUT) \
         --set storage.storageClass=$(NFS_STORAGE_CLASS) \
-        --set storage.pvcSizes.log.chronos=$(PVC_DEFAULT_STORAGE_SIZE) \
-        --set storage.pvcSizes.log.edify=$(PVC_DEFAULT_STORAGE_SIZE) \
-        --set storage.pvcSizes.log.executor=$(PVC_DEFAULT_STORAGE_SIZE) \
-        --set storage.pvcSizes.log.glass=$(PVC_DEFAULT_STORAGE_SIZE) \
-        --set storage.pvcSizes.log.griffon=$(PVC_DEFAULT_STORAGE_SIZE) \
-        --set storage.pvcSizes.log.pigeon=$(PVC_DEFAULT_STORAGE_SIZE) \
-        --set storage.pvcSizes.log.proximityApi=$(PVC_DEFAULT_STORAGE_SIZE) \
-        --set storage.pvcSizes.log.proximityCli=$(PVC_DEFAULT_STORAGE_SIZE) \
-        --set storage.pvcSizes.log.transcript=$(PVC_DEFAULT_STORAGE_SIZE) \
-        --set storage.pvcSizes.log.use=$(PVC_DEFAULT_STORAGE_SIZE) \
-        --set storage.pvcSizes.config.etl=$(PVC_DEFAULT_STORAGE_SIZE) \
-        --set storage.pvcSizes.config.griffon=$(PVC_DEFAULT_STORAGE_SIZE) \
-        --set storage.pvcSizes.config.chronos=$(PVC_DEFAULT_STORAGE_SIZE) \
-        --set storage.pvcSizes.data.exported=$(PVC_DEFAULT_STORAGE_SIZE) \
-        --set storage.pvcSizes.data.extracted=$(PVC_DEFAULT_STORAGE_SIZE) \
-        --set storage.pvcSizes.data.import=$(PVC_DEFAULT_STORAGE_SIZE) \
-        --set storage.pvcSizes.data.report=$(PVC_DEFAULT_STORAGE_SIZE) \
         --set ingress.host=$(INGRESS_HOSTNAME) \
         --set ingress.ingressClassName="nginx" \
         --set logLevel.backend="debug" \
@@ -60,7 +41,7 @@ deploy-nfs-chart:
         --debug \
         --timeout $(HELM_TIMEOUT) \
         --set persistence.enabled=true \
-        --set persistence.size=5Gi \
+        --set persistence.size=20Gi \
         --set storageClass.name=$(NFS_STORAGE_CLASS) \
         --set storageClass.allowVolumeExpansion=true \
         --set 'storageClass.mountOptions[0]=nfsvers=4.2' \

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 NFS_STORAGE_CLASS := nfs-client
 NFS_CHART_VERSION := 1.8.0
 
+PVC_DEFAULT_STORAGE_SIZE := 200Mi
+
 INGRESS_HOSTNAME := exivity.local
 
 HELM_TIMEOUT := 10m
@@ -24,6 +26,23 @@ deploy-exivity-chart:
         --debug \
         --timeout $(HELM_TIMEOUT) \
         --set storage.storageClass=$(NFS_STORAGE_CLASS) \
+        --set storage.pvcSizes.log.chronos=$(PVC_DEFAULT_STORAGE_SIZE) \
+        --set storage.pvcSizes.log.edify=$(PVC_DEFAULT_STORAGE_SIZE) \
+        --set storage.pvcSizes.log.executor=$(PVC_DEFAULT_STORAGE_SIZE) \
+        --set storage.pvcSizes.log.glass=$(PVC_DEFAULT_STORAGE_SIZE) \
+        --set storage.pvcSizes.log.griffon=$(PVC_DEFAULT_STORAGE_SIZE) \
+        --set storage.pvcSizes.log.pigeon=$(PVC_DEFAULT_STORAGE_SIZE) \
+        --set storage.pvcSizes.log.proximityApi=$(PVC_DEFAULT_STORAGE_SIZE) \
+        --set storage.pvcSizes.log.proximityCli=$(PVC_DEFAULT_STORAGE_SIZE) \
+        --set storage.pvcSizes.log.transcript=$(PVC_DEFAULT_STORAGE_SIZE) \
+        --set storage.pvcSizes.log.use=$(PVC_DEFAULT_STORAGE_SIZE) \
+        --set storage.pvcSizes.config.etl=$(PVC_DEFAULT_STORAGE_SIZE) \
+        --set storage.pvcSizes.config.griffon=$(PVC_DEFAULT_STORAGE_SIZE) \
+        --set storage.pvcSizes.config.chronos=$(PVC_DEFAULT_STORAGE_SIZE) \
+        --set storage.pvcSizes.data.exported=$(PVC_DEFAULT_STORAGE_SIZE) \
+        --set storage.pvcSizes.data.extracted=$(PVC_DEFAULT_STORAGE_SIZE) \
+        --set storage.pvcSizes.data.import=$(PVC_DEFAULT_STORAGE_SIZE) \
+        --set storage.pvcSizes.data.report=$(PVC_DEFAULT_STORAGE_SIZE) \
         --set ingress.host=$(INGRESS_HOSTNAME) \
         --set ingress.ingressClassName="nginx" \
         --set logLevel.backend="debug" \
@@ -65,7 +84,7 @@ install-python-deps:
 test:
 	@echo "Running tests..."
 	@python3 test/test.py --hostname $(INGRESS_HOSTNAME) --ip $$(minikube ip)
-        
+
 # Lint Helm chart
 lint:
 	@helm lint charts/exivity

--- a/charts/exivity/templates/chronos/persistentvolumeclaim.yaml
+++ b/charts/exivity/templates/chronos/persistentvolumeclaim.yaml
@@ -10,7 +10,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+      storage: {{ .Values.storage.pvcSizes.config.chronos }}
 {{- if .Values.storage.storageClass }}
   storageClassName: {{ .Values.storage.storageClass }}
 {{ end }}
@@ -28,7 +28,7 @@ spec:
     - {{ .Values.storage.sharedVolumeAccessMode }}
   resources:
     requests:
-      storage: 1Gi
+      storage: {{ .Values.storage.pvcSizes.log.chronos }}
 {{- if .Values.storage.storageClass }}
   storageClassName: {{ .Values.storage.storageClass }}
 {{ end }}

--- a/charts/exivity/templates/edify/persistentvolumeclaim.yaml
+++ b/charts/exivity/templates/edify/persistentvolumeclaim.yaml
@@ -10,7 +10,7 @@ spec:
     - {{ .Values.storage.sharedVolumeAccessMode }}
   resources:
     requests:
-      storage: 1Gi
+      storage: {{ .Values.storage.pvcSizes.log.edify }}
 {{- if .Values.storage.storageClass }}
   storageClassName: {{ .Values.storage.storageClass }}
 {{ end }}

--- a/charts/exivity/templates/executor/persistentvolumeclaim.yaml
+++ b/charts/exivity/templates/executor/persistentvolumeclaim.yaml
@@ -10,7 +10,7 @@ spec:
     - {{ .Values.storage.sharedVolumeAccessMode }}
   resources:
     requests:
-      storage: 1Gi
+      storage: {{ .Values.storage.pvcSizes.log.executor }}
 {{- if .Values.storage.storageClass }}
   storageClassName: {{ .Values.storage.storageClass }}
 {{ end }}

--- a/charts/exivity/templates/glass/persistentvolumeclaim.yaml
+++ b/charts/exivity/templates/glass/persistentvolumeclaim.yaml
@@ -10,7 +10,7 @@ spec:
     - {{ .Values.storage.sharedVolumeAccessMode }}
   resources:
     requests:
-      storage: 1Gi
+      storage: {{ .Values.storage.pvcSizes.log.glass }}
 {{- if .Values.storage.storageClass }}
   storageClassName: {{ .Values.storage.storageClass }}
 {{ end }}

--- a/charts/exivity/templates/griffon/persistentvolumeclaim.yaml
+++ b/charts/exivity/templates/griffon/persistentvolumeclaim.yaml
@@ -10,7 +10,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+      storage: {{ .Values.storage.pvcSizes.config.griffon }}
 {{- if .Values.storage.storageClass }}
   storageClassName: {{ .Values.storage.storageClass }}
 {{ end }}
@@ -29,7 +29,7 @@ spec:
     - {{ .Values.storage.sharedVolumeAccessMode }}
   resources:
     requests:
-      storage: 1Gi
+      storage: {{ .Values.storage.pvcSizes.log.griffon }}
 {{- if .Values.storage.storageClass }}
   storageClassName: {{ .Values.storage.storageClass }}
 {{ end }}

--- a/charts/exivity/templates/horizon/persistentvolumeclaim.yaml
+++ b/charts/exivity/templates/horizon/persistentvolumeclaim.yaml
@@ -10,7 +10,7 @@ spec:
     - {{ .Values.storage.sharedVolumeAccessMode }}
   resources:
     requests:
-      storage: 1Gi
+      storage: {{ .Values.storage.pvcSizes.log.horizon }}
 {{- if .Values.storage.storageClass }}
   storageClassName: {{ .Values.storage.storageClass }}
 {{ end }}

--- a/charts/exivity/templates/persistentvolumeclaim.yaml
+++ b/charts/exivity/templates/persistentvolumeclaim.yaml
@@ -13,7 +13,7 @@ spec:
     - {{ .Values.storage.sharedVolumeAccessMode }}
   resources:
     requests:
-      storage: 1Gi
+      storage: {{ .Values.storage.pvcSizes.config.etl }}
 {{- if .Values.storage.storageClass }}
   storageClassName: {{ .Values.storage.storageClass }}
 {{ end }}
@@ -34,7 +34,7 @@ spec:
     - {{ .Values.storage.sharedVolumeAccessMode }}
   resources:
     requests:
-      storage: 1Gi
+      storage: {{ .Values.storage.pvcSizes.data.exported }}
 {{- if .Values.storage.storageClass }}
   storageClassName: {{ .Values.storage.storageClass }}
 {{ end }}
@@ -55,7 +55,7 @@ spec:
     - {{ .Values.storage.sharedVolumeAccessMode }}
   resources:
     requests:
-      storage: 1Gi
+      storage: {{ .Values.storage.pvcSizes.data.extracted }}
 {{- if .Values.storage.storageClass }}
   storageClassName: {{ .Values.storage.storageClass }}
 {{ end }}
@@ -76,7 +76,7 @@ spec:
     - {{ .Values.storage.sharedVolumeAccessMode }}
   resources:
     requests:
-      storage: 1Gi
+      storage: {{ .Values.storage.pvcSizes.data.import }}
 {{- if .Values.storage.storageClass }}
   storageClassName: {{ .Values.storage.storageClass }}
 {{ end }}
@@ -97,7 +97,7 @@ spec:
     - {{ .Values.storage.sharedVolumeAccessMode }}
   resources:
     requests:
-      storage: 1Gi
+      storage: {{ .Values.storage.pvcSizes.data.report }}
 {{- if .Values.storage.storageClass }}
   storageClassName: {{ .Values.storage.storageClass }}
 {{ end }}

--- a/charts/exivity/templates/pigeon/persistentvolumeclaim.yaml
+++ b/charts/exivity/templates/pigeon/persistentvolumeclaim.yaml
@@ -10,7 +10,7 @@ spec:
     - {{ .Values.storage.sharedVolumeAccessMode }}
   resources:
     requests:
-      storage: 1Gi
+      storage: {{ .Values.storage.pvcSizes.log.pigeon }}
 {{- if .Values.storage.storageClass }}
   storageClassName: {{ .Values.storage.storageClass }}
 {{ end }}

--- a/charts/exivity/templates/proximity/api.persistentvolumeclaim.yaml
+++ b/charts/exivity/templates/proximity/api.persistentvolumeclaim.yaml
@@ -10,7 +10,7 @@ spec:
     - {{ .Values.storage.sharedVolumeAccessMode }}
   resources:
     requests:
-      storage: 1Gi
+      storage: {{ .Values.storage.pvcSizes.log.proximityApi }}
 {{- if .Values.storage.storageClass }}
   storageClassName: {{ .Values.storage.storageClass }}
 {{ end }}

--- a/charts/exivity/templates/proximity/cli.persistentvolumeclaim.yaml
+++ b/charts/exivity/templates/proximity/cli.persistentvolumeclaim.yaml
@@ -10,7 +10,7 @@ spec:
     - {{ .Values.storage.sharedVolumeAccessMode }}
   resources:
     requests:
-      storage: 1Gi
+      storage: {{ .Values.storage.pvcSizes.log.proximityCli }}
 {{- if .Values.storage.storageClass }}
   storageClassName: {{ .Values.storage.storageClass }}
 {{ end }}

--- a/charts/exivity/templates/transcript/persistentvolumeclaim.yaml
+++ b/charts/exivity/templates/transcript/persistentvolumeclaim.yaml
@@ -10,7 +10,7 @@ spec:
     - {{ .Values.storage.sharedVolumeAccessMode }}
   resources:
     requests:
-      storage: 1Gi
+      storage: {{ .Values.storage.pvcSizes.log.transcript }}
 {{- if .Values.storage.storageClass }}
   storageClassName: {{ .Values.storage.storageClass }}
 {{ end }}

--- a/charts/exivity/templates/use/persistentvolumeclaim.yaml
+++ b/charts/exivity/templates/use/persistentvolumeclaim.yaml
@@ -10,7 +10,7 @@ spec:
     - {{ .Values.storage.sharedVolumeAccessMode }}
   resources:
     requests:
-      storage: 1Gi
+      storage: {{ .Values.storage.pvcSizes.log.use }}
 {{- if .Values.storage.storageClass }}
   storageClassName: {{ .Values.storage.storageClass }}
 {{ end }}

--- a/charts/exivity/values.schema.json
+++ b/charts/exivity/values.schema.json
@@ -2967,6 +2967,45 @@
           }
         }
       ]
+    },
+    "pvcSizes": {
+      "type": "object",
+      "title": "The pvcSizes Schema",
+      "properties": {
+        "log": {
+          "type": "object",
+          "properties": {
+            "chronos": { "type": "string" },
+            "edify": { "type": "string" },
+            "executor": { "type": "string" },
+            "glass": { "type": "string" },
+            "griffon": { "type": "string" },
+            "horizon": { "type": "string" },
+            "pigeon": { "type": "string" },
+            "proximityApi": { "type": "string" },
+            "proximityCli": { "type": "string" },
+            "transcript": { "type": "string" },
+            "use": { "type": "string" }
+          }
+        },
+        "config": {
+          "type": "object",
+          "properties": {
+            "etl": { "type": "string" },
+            "griffon": { "type": "string" },
+            "chronos": { "type": "string" }
+          }
+        },
+        "data": {
+          "type": "object",
+          "properties": {
+            "exported": { "type": "string" },
+            "extracted": { "type": "string" },
+            "import": { "type": "string" },
+            "report": { "type": "string" }
+          }
+        }
+      }
     }
   },
   "examples": [

--- a/charts/exivity/values.yaml
+++ b/charts/exivity/values.yaml
@@ -48,16 +48,16 @@ storage:
     # Log PVCs
     log:
       chronos: 1Gi
-      edify: 5Gi
+      edify: 1Gi
       executor: 1Gi
       glass: 1Gi
       griffon: 1Gi
       horizon: 1Gi
       pigeon: 1Gi
-      proximityApi: 5Gi
+      proximityApi: 1Gi
       proximityCli: 1Gi
-      transcript: 5Gi
-      use: 5Gi
+      transcript: 1Gi
+      use: 1Gi
 
     # Config PVCs
     config:
@@ -67,10 +67,10 @@ storage:
 
     # Data PVCs
     data:
-      exported: 30Gi
-      extracted: 30Gi
-      import: 30Gi
-      report: 30Gi
+      exported: 1Gi
+      extracted: 1Gi
+      import: 1Gi
+      report: 1Gi
 
 # Configuration for PostgreSQL, either as an embedded database using the Bitnami PostgreSQL chart or an external database.
 # It is recommended to use an external PostgreSQL server for production environments to ensure scalability and manageability.

--- a/charts/exivity/values.yaml
+++ b/charts/exivity/values.yaml
@@ -39,6 +39,37 @@ storage:
   helmResourcePolicyKeep: true # Ensures that storage resources are retained after a Helm release is deleted.
   sharedVolumeAccessMode: ReadWriteMany # Defines the access mode for shared volumes; 'ReadWriteMany' allows multiple nodes to read/write simultaneously.
 
+  # PVC storage sizes organized by type and component
+  # Specify the storage size for each PVC as a string (e.g., "1Gi", "500Mi", etc.).
+  # The sizes are grouped by their purpose (log, config, data) and component for better clarity.
+  pvcSizes:
+    # Log PVCs
+    log:
+      chronos: 1Gi
+      edify: 1Gi
+      executor: 1Gi
+      glass: 1Gi
+      griffon: 1Gi
+      horizon: 1Gi
+      pigeon: 1Gi
+      proximityApi: 1Gi
+      proximityCli: 1Gi
+      transcript: 1Gi
+      use: 1Gi
+
+    # Config PVCs
+    config:
+      etl: 1Gi
+      griffon: 1Gi
+      chronos: 1Gi
+
+    # Data PVCs
+    data:
+      exported: 10Gi
+      extracted: 10Gi
+      import: 10Gi
+      report: 10Gi
+
 # Configuration for PostgreSQL, either as an embedded database using the Bitnami PostgreSQL chart or an external database.
 # It is recommended to use an external PostgreSQL server for production environments to ensure scalability and manageability.
 # The embedded PostgreSQL chart is primarily intended for testing and non-production purposes.

--- a/charts/exivity/values.yaml
+++ b/charts/exivity/values.yaml
@@ -42,6 +42,8 @@ storage:
   # PVC storage sizes organized by type and component
   # Specify the storage size for each PVC as a string (e.g., "1Gi", "500Mi", etc.).
   # The sizes are grouped by their purpose (log, config, data) and component for better clarity.
+  # NOTE: These sizes will be ignored when using the NFS server (https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner)
+  # as a storage provider / storage class, since that provisioner does not enforce PVC size limits.
   pvcSizes:
     # Log PVCs
     log:

--- a/charts/exivity/values.yaml
+++ b/charts/exivity/values.yaml
@@ -42,8 +42,14 @@ storage:
   # PVC storage sizes organized by type and component
   # Specify the storage size for each PVC as a string (e.g., "1Gi", "500Mi", etc.).
   # The sizes are grouped by their purpose (log, config, data) and component for better clarity.
-  # NOTE: These sizes will be ignored when using the NFS server (https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner)
-  # as a storage provider / storage class, since that provisioner does not enforce PVC size limits.
+  #
+  # When the NFS server provisioner (https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner)
+  # is used as the storage provider, the configured PVC sizes will not be enforced.
+  # In this case, each PVC may consume up to the total available space on the NFS server, regardless of the size specified here.
+  # Therefore, the default values for PVC sizes should not be changed when NFS is used, to ensure compatibility with existing deployments and to avoid unexpected behavior.
+  #
+  # When an alternative CSI storage provider (such as Longhorn) is used, the specified PVC sizes will be enforced by the storage backend.
+  # In such cases, it is recommended that the PVC sizes for data and log volumes be increased according to the requirements of the production workload, as the default values may be insufficient.
   pvcSizes:
     # Log PVCs
     log:

--- a/charts/exivity/values.yaml
+++ b/charts/exivity/values.yaml
@@ -48,16 +48,16 @@ storage:
     # Log PVCs
     log:
       chronos: 1Gi
-      edify: 1Gi
+      edify: 5Gi
       executor: 1Gi
       glass: 1Gi
       griffon: 1Gi
       horizon: 1Gi
       pigeon: 1Gi
-      proximityApi: 1Gi
+      proximityApi: 5Gi
       proximityCli: 1Gi
-      transcript: 1Gi
-      use: 1Gi
+      transcript: 5Gi
+      use: 5Gi
 
     # Config PVCs
     config:
@@ -67,10 +67,10 @@ storage:
 
     # Data PVCs
     data:
-      exported: 10Gi
-      extracted: 10Gi
-      import: 10Gi
-      report: 10Gi
+      exported: 30Gi
+      extracted: 30Gi
+      import: 30Gi
+      report: 30Gi
 
 # Configuration for PostgreSQL, either as an embedded database using the Bitnami PostgreSQL chart or an external database.
 # It is recommended to use an external PostgreSQL server for production environments to ensure scalability and manageability.


### PR DESCRIPTION
Refactor PersistentVolumeClaims to utilize dynamic storage sizes defined in values.yaml, enhancing flexibility and configurability for different components.