### PR TITLE
feat: Add PostgreSQL backup and restore jobs with Helm configuration

### DIFF
--- a/charts/exivity/templates/backup/job.yaml
+++ b/charts/exivity/templates/backup/job.yaml
@@ -42,25 +42,11 @@ spec:
               value: "{{ .Values.service.backup.filePrefix }}"
             - name: BACKUP_RETENTION_DAYS
               value: "{{ .Values.service.backup.retentionDays }}"
-            - name: DB_HOST
-              value: {{ .Values.postgresql.host | default (printf "%s-postgresql" (include "exivity.fullname" . )) | quote }}
-            - name: DB_PORT
-              value: {{ .Values.postgresql.port | default 5432 | quote }}
-            - name: DB_USER
-              value: {{ .Values.postgresql.global.postgresql.auth.username | quote }}
-            - name: DB_PASSWORD
-              {{- if empty .Values.postgresql.host }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "exivity.fullname" . }}-postgresql
-                  key: password
-              {{- else }}
-              value: {{ .Values.postgresql.global.postgresql.auth.password | quote }}
-              {{- end }}
-            - name: DB_NAME
-              value: {{ .Values.postgresql.global.postgresql.auth.database | quote }}
-            - name: PG_SSLMODE
-              value: {{ .Values.postgresql.sslmode | default "disable" | quote }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "exivity.fullname" . }}-postgres-config
+            - secretRef:
+                name: {{ include "exivity.fullname" . }}-postgres-secret
           resources:
             {{- toYaml .Values.service.backup.resources | nindent 12 }}
           volumeMounts:

--- a/charts/exivity/templates/backup/job.yaml
+++ b/charts/exivity/templates/backup/job.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.service.backup.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "exivity.fullname" . }}-db-backup
+  labels:
+    app.kubernetes.io/component: db-backup
+    {{- include "exivity.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded
+    helm.sh/hook-weight: "-1" # Run before migration (which has weight "0")
+spec:
+  completions: 1
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: db-backup
+        {{- include "exivity.labels" . | nindent 8 }}
+    spec:
+      securityContext:
+        {{- include "exivity.securityContext" (dict "root" . "component" "backup") | nindent 8 }}
+      volumes:
+        - name: backup-storage
+          persistentVolumeClaim:
+            claimName: {{ include "exivity.fullname" . }}-backup
+        {{- include "exivity.permissionScriptVolume" . | nindent 8 }}
+      initContainers:
+      {{- include "exivity.initPermissionsContainer" (dict "root" . "component" "backup" "volumes" (list "backup-storage")) | nindent 8 }}
+      containers:
+        - name: db-backup
+          image: {{ include "exivity.image" (set . "name" "backup") }}
+          imagePullPolicy: {{ .Values.service.backup.pullPolicy | default .Values.service.pullPolicy | default "IfNotPresent" }}
+          command: ["backup"]
+          args:
+            - "{{ .Values.service.backup.filePrefix }}_$(date +%Y%m%d_%H%M%S).sql.gz"
+          env:
+            - name: BACKUP_DIR_PATH
+              value: "/backups"
+            - name: BACKUP_FILE_PREFIX
+              value: "{{ .Values.service.backup.filePrefix }}"
+            - name: BACKUP_RETENTION_DAYS
+              value: "{{ .Values.service.backup.retentionDays }}"
+            - name: DB_HOST
+              value: {{ .Values.postgresql.host | default (printf "%s-postgresql" (include "exivity.fullname" . )) | quote }}
+            - name: DB_PORT
+              value: {{ .Values.postgresql.port | default 5432 | quote }}
+            - name: DB_USER
+              value: {{ .Values.postgresql.global.postgresql.auth.username | quote }}
+            - name: DB_PASSWORD
+              {{- if empty .Values.postgresql.host }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "exivity.fullname" . }}-postgresql
+                  key: password
+              {{- else }}
+              value: {{ .Values.postgresql.global.postgresql.auth.password | quote }}
+              {{- end }}
+            - name: DB_NAME
+              value: {{ .Values.postgresql.global.postgresql.auth.database | quote }}
+            - name: PG_SSLMODE
+              value: {{ .Values.postgresql.sslmode | default "disable" | quote }}
+          resources:
+            {{- toYaml .Values.service.backup.resources | nindent 12 }}
+          volumeMounts:
+            - name: backup-storage
+              mountPath: /backups
+      restartPolicy: Never
+      {{- with .Values.service.pullSecrets }}
+      imagePullSecrets:
+        {{- range $name := .}}
+        - name: {{ $name }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.service.backup.nodeName }}
+      nodeName: {{ .Values.service.backup.nodeName }}
+      {{- end }}
+      {{- include "exivity.tolerations" (dict "Values" .Values "component" .Values.service.backup) | nindent 6 }}
+      {{- include "exivity.nodeSelector" (dict "Values" .Values "component" .Values.service.backup) | nindent 6 }}
+      affinity:
+        {{- include "exivity.nodeAffinity" (dict "Values" .Values "component" .Values.service.backup) | nindent 8 }}
+{{- end }}

--- a/charts/exivity/templates/backup/job.yaml
+++ b/charts/exivity/templates/backup/job.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: db-backup
     {{- include "exivity.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook": post-upgrade,post-install
     "helm.sh/hook-delete-policy": hook-succeeded
     helm.sh/hook-weight: "-1" # Run before migration (which has weight "0")
 spec:

--- a/charts/exivity/templates/backup/job.yaml
+++ b/charts/exivity/templates/backup/job.yaml
@@ -33,8 +33,6 @@ spec:
           image: {{ include "exivity.image" (set . "name" "backup") }}
           imagePullPolicy: {{ .Values.service.backup.pullPolicy | default .Values.service.pullPolicy | default "IfNotPresent" }}
           command: ["backup"]
-          args:
-            - "{{ .Values.service.backup.filePrefix }}_$(date +%Y%m%d_%H%M%S).sql.gz"
           env:
             - name: BACKUP_DIR_PATH
               value: "/backups"

--- a/charts/exivity/templates/backup/persistentvolumeclaim.yaml
+++ b/charts/exivity/templates/backup/persistentvolumeclaim.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.service.backup.enabled }}
+{{- if or .Values.service.backup.enabled .Values.service.restore.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -7,13 +7,13 @@ metadata:
     app.kubernetes.io/component: backup
     {{- include "exivity.labels" . | nindent 4 }}
   {{- with .Values.service.backup.storage.labels }}
-  {{- toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   annotations:
-    helm.sh/resource-policy: {{ .Values.storage.helmResourcePolicyKeep | ternary "keep" "delete" }}
-  {{- with .Values.service.backup.storage.annotations }}
-  {{- toYaml . | nindent 4 }}
-  {{- end }}
+    "helm.sh/resource-policy": {{ .Values.service.backup.storage.helmResourcePolicy | quote }}
+    {{- with .Values.service.backup.storage.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.service.backup.storage.storageClass }}
   storageClassName: {{ .Values.service.backup.storage.storageClass }}

--- a/charts/exivity/templates/backup/persistentvolumeclaim.yaml
+++ b/charts/exivity/templates/backup/persistentvolumeclaim.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.service.backup.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "exivity.fullname" . }}-backup
+  labels:
+    app.kubernetes.io/component: backup
+    {{- include "exivity.labels" . | nindent 4 }}
+  {{- with .Values.service.backup.storage.labels }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  annotations:
+    helm.sh/resource-policy: {{ .Values.storage.helmResourcePolicyKeep | ternary "keep" "delete" }}
+  {{- with .Values.service.backup.storage.annotations }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.service.backup.storage.storageClass }}
+  storageClassName: {{ .Values.service.backup.storage.storageClass }}
+  {{- end }}
+  accessModes:
+  {{- range .Values.service.backup.storage.accessModes }}
+    - {{ . }}
+  {{- end }}
+  {{- if .Values.service.backup.storage.volumeMode }}
+  volumeMode: {{ .Values.service.backup.storage.volumeMode }}
+  {{- end }}
+  {{- with .Values.service.backup.storage.selector }}
+  selector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.service.backup.storage.size }}
+{{- end }}

--- a/charts/exivity/templates/migration/job.yaml
+++ b/charts/exivity/templates/migration/job.yaml
@@ -22,32 +22,11 @@ spec:
         - name: migration
           image: {{ include "exivity.image" (set $ "name" "dbInit") }}
           imagePullPolicy: {{ .Values.service.dbInit.pullPolicy | default .Values.service.pullPolicy | default "IfNotPresent" }}
-          args:
-            - "-path"
-            - "./migrations"
-            - "-database"
-            - "postgres://$(PG_USER):$(PG_PASSWORD)@$(PG_HOST):$(PG_PORT)/$(PG_DATABASE)?sslmode=$(PG_SSLMODE)"
-            - "up"
-          env:
-            - name: PG_USER
-              value: {{ $.Values.postgresql.global.postgresql.auth.username | quote }}
-            - name: PG_PASSWORD
-              {{- if empty $.Values.postgresql.host }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "exivity.fullname" $ -}}-postgresql
-                  key:                                      password
-              {{- else }}
-              value: {{ $.Values.postgresql.global.postgresql.auth.password | quote }}
-              {{- end }}
-            - name: PG_DATABASE
-              value: {{ $.Values.postgresql.global.postgresql.auth.database | quote }}
-            - name: PG_HOST
-              value: {{ $.Values.postgresql.host | default (printf "%s-postgresql" (include "exivity.fullname" $ )) | quote }}
-            - name: PG_PORT
-              value: {{ $.Values.postgresql.port | default 5432 | quote}}
-            - name: PG_SSLMODE
-              value: {{ $.Values.postgresql.sslmode | default "disable" | quote  }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "exivity.fullname" . }}-postgres-config
+            - secretRef:
+                name: {{ include "exivity.fullname" . }}-postgres-secret
           resources:
             {{- toYaml .Values.service.dbInit.migration.resources | nindent 12 }}
       restartPolicy: Never

--- a/charts/exivity/templates/postgres-configmap.yaml
+++ b/charts/exivity/templates/postgres-configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "exivity.fullname" . }}-postgres-config
+  labels:
+    app.kubernetes.io/component: postgres-config
+    {{- include "exivity.labels" . | nindent 4 }}
+data:
+  POSTGRES_HOST: {{ .Values.postgresql.host | default (printf "%s-postgresql" (include "exivity.fullname" . )) | quote }}
+  POSTGRES_PORT: {{ .Values.postgresql.port | quote }}
+  POSTGRES_DB: {{ .Values.postgresql.global.postgresql.auth.database | quote }}
+  POSTGRES_USER: {{ .Values.postgresql.global.postgresql.auth.username | quote }}
+  POSTGRES_SSLMODE: {{ .Values.postgresql.sslmode | default "disable" | quote }}

--- a/charts/exivity/templates/postgres-secret.yaml
+++ b/charts/exivity/templates/postgres-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "exivity.fullname" . }}-postgres-secret
+  labels:
+    app.kubernetes.io/component: postgres-secret
+    {{- include "exivity.labels" . | nindent 4 }}
+type: Opaque
+data:
+  POSTGRES_PASSWORD: {{ .Values.postgresql.global.postgresql.auth.password | b64enc | quote }}

--- a/charts/exivity/templates/restore/job.yaml
+++ b/charts/exivity/templates/restore/job.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.service.restore.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "exivity.fullname" . }}-db-restore
+  labels:
+    app.kubernetes.io/component: db-restore
+    {{- include "exivity.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded
+    helm.sh/hook-weight: "-2" # Run before backup (which has weight "-1")
+spec:
+  completions: 1
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: db-restore
+        {{- include "exivity.labels" . | nindent 8 }}
+    spec:
+      securityContext:
+        {{- include "exivity.securityContext" (dict "root" . "component" "restore") | nindent 8 }}
+      volumes:
+        - name: backup-storage
+          persistentVolumeClaim:
+            claimName: {{ include "exivity.fullname" . }}-backup
+        {{- include "exivity.permissionScriptVolume" . | nindent 8 }}
+      containers:
+        - name: db-restore
+          image: {{ include "exivity.image" (set . "name" "restore") }}
+          imagePullPolicy: {{ .Values.service.restore.pullPolicy | default .Values.service.pullPolicy | default "IfNotPresent" }}
+          command: ["restore"]
+          env:
+            - name: BACKUP_DIR_PATH
+              value: "/backups"
+            {{- if .Values.service.restore.backupFilename }}
+            - name: BACKUP_FILENAME
+              value: "{{ .Values.service.restore.backupFilename }}"
+            {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "exivity.fullname" . }}-postgres-config
+            - secretRef:
+                name: {{ include "exivity.fullname" . }}-postgres-secret
+          resources:
+            {{- toYaml .Values.service.restore.resources | nindent 12 }}
+          volumeMounts:
+            - name: backup-storage
+              mountPath: /backups
+      restartPolicy: Never
+      {{- with .Values.service.pullSecrets }}
+      imagePullSecrets:
+        {{- range $name := .}}
+        - name: {{ $name }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.service.restore.nodeName }}
+      nodeName: {{ .Values.service.restore.nodeName }}
+      {{- end }}
+      {{- include "exivity.tolerations" (dict "Values" .Values "component" .Values.service.restore) | nindent 6 }}
+      {{- include "exivity.nodeSelector" (dict "Values" .Values "component" .Values.service.restore) | nindent 6 }}
+      affinity:
+        {{- include "exivity.nodeAffinity" (dict "Values" .Values "component" .Values.service.restore) | nindent 8 }}
+{{- end }}

--- a/charts/exivity/templates/restore/job.yaml
+++ b/charts/exivity/templates/restore/job.yaml
@@ -31,13 +31,12 @@ spec:
           image: {{ include "exivity.image" (set . "name" "restore") }}
           imagePullPolicy: {{ .Values.service.restore.pullPolicy | default .Values.service.pullPolicy | default "IfNotPresent" }}
           command: ["restore"]
+          {{- if .Values.service.restore.backupFilename }}
+          args: ["{{ .Values.service.restore.backupFilename }}"]
+          {{- end }}
           env:
             - name: BACKUP_DIR_PATH
               value: "/backups"
-            {{- if .Values.service.restore.backupFilename }}
-            - name: BACKUP_FILENAME
-              value: "{{ .Values.service.restore.backupFilename }}"
-            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "exivity.fullname" . }}-postgres-config

--- a/charts/exivity/templates/restore/job.yaml
+++ b/charts/exivity/templates/restore/job.yaml
@@ -1,3 +1,7 @@
+{{- if and .Values.service.restore.enabled .Values.service.backup.enabled }}
+{{- fail "You cannot enable both backup and restore at the same time. Please disable one of them." }}
+{{- end }}
+
 {{- if .Values.service.restore.enabled }}
 apiVersion: batch/v1
 kind: Job

--- a/charts/exivity/values.schema.json
+++ b/charts/exivity/values.schema.json
@@ -1414,6 +1414,239 @@
             }
           ]
         },
+        "backup": {
+          "type": "object",
+          "default": {},
+          "title": "The backup Schema",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "title": "Enable backup job"
+            },
+            "registry": {
+              "type": "string",
+              "default": "",
+              "title": "The registry Schema"
+            },
+            "repository": {
+              "type": "string",
+              "default": "",
+              "title": "The repository Schema"
+            },
+            "tag": {
+              "type": "string",
+              "default": "",
+              "title": "The tag Schema"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "default": "",
+              "title": "The pullPolicy Schema"
+            },
+            "nodeName": {
+              "type": "string",
+              "default": "",
+              "title": "The nodeName Schema"
+            },
+            "nodeSelector": {
+              "type": "object",
+              "title": "The nodeSelector Schema",
+              "properties": {},
+              "examples": [{}]
+            },
+            "nodeAffinity": {
+              "type": "object",
+              "default": {},
+              "title": "The nodeAffinity Schema",
+              "properties": {},
+              "examples": [{}]
+            },
+            "tolerations": {
+              "type": "array",
+              "default": [],
+              "title": "The tolerations Schema",
+              "items": {},
+              "examples": [[]]
+            },
+            "resources": {
+              "type": "object",
+              "default": {},
+              "title": "The resources Schema",
+              "properties": {
+                "requests": {
+                  "type": "object",
+                  "default": {},
+                  "title": "The requests Schema",
+                  "properties": {
+                    "cpu": {
+                      "type": "string",
+                      "default": "",
+                      "title": "The cpu Schema"
+                    },
+                    "memory": {
+                      "type": "string",
+                      "default": "",
+                      "title": "The memory Schema"
+                    }
+                  },
+                  "examples": [{ "cpu": "25m", "memory": "50Mi" }]
+                }
+              },
+              "examples": [{ "requests": { "cpu": "25m", "memory": "50Mi" } }]
+            },
+            "retentionDays": {
+              "type": "integer",
+              "default": 7,
+              "title": "Number of days to retain backups",
+              "minimum": 0
+            },
+            "filePrefix": {
+              "type": "string",
+              "default": "backup",
+              "title": "Prefix for backup files"
+            },
+            "storage": {
+              "type": "object",
+              "default": {},
+              "title": "Backup storage configuration",
+              "properties": {
+                "size": {
+                  "type": "string",
+                  "default": "10Gi",
+                  "title": "Size of the backup PVC"
+                },
+                "storageClass": {
+                  "type": "string",
+                  "default": "",
+                  "title": "Custom storage class for backup PVC"
+                },
+                "accessModes": {
+                  "type": "array",
+                  "default": ["ReadWriteOnce"],
+                  "title": "Access modes for backup PVC",
+                  "items": { "type": "string" }
+                },
+                "volumeMode": {
+                  "type": "string",
+                  "default": "Filesystem",
+                  "title": "Volume mode"
+                },
+                "helmResourcePolicy": {
+                  "type": "string",
+                  "default": "keep",
+                  "title": "Whether to keep or delete the PVC on Helm uninstall"
+                },
+                "selector": {
+                  "type": "object",
+                  "title": "PVC selector",
+                  "properties": {},
+                  "examples": [{}]
+                },
+                "annotations": {
+                  "type": "object",
+                  "title": "PVC annotations",
+                  "properties": {},
+                  "examples": [{}]
+                },
+                "labels": {
+                  "type": "object",
+                  "title": "PVC labels",
+                  "properties": {},
+                  "examples": [{}]
+                }
+              }
+            }
+          }
+        },
+        "restore": {
+          "type": "object",
+          "default": {},
+          "title": "The restore Schema",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "title": "Enable restore job"
+            },
+            "registry": {
+              "type": "string",
+              "default": "",
+              "title": "The registry Schema"
+            },
+            "repository": {
+              "type": "string",
+              "default": "",
+              "title": "The repository Schema"
+            },
+            "tag": {
+              "type": "string",
+              "default": "",
+              "title": "The tag Schema"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "default": "",
+              "title": "The pullPolicy Schema"
+            },
+            "nodeName": {
+              "type": "string",
+              "default": "",
+              "title": "The nodeName Schema"
+            },
+            "nodeSelector": {
+              "type": "object",
+              "title": "The nodeSelector Schema",
+              "properties": {},
+              "examples": [{}]
+            },
+            "nodeAffinity": {
+              "type": "object",
+              "default": {},
+              "title": "The nodeAffinity Schema",
+              "properties": {},
+              "examples": [{}]
+            },
+            "tolerations": {
+              "type": "array",
+              "default": [],
+              "title": "The tolerations Schema",
+              "items": {},
+              "examples": [[]]
+            },
+            "resources": {
+              "type": "object",
+              "default": {},
+              "title": "The resources Schema",
+              "properties": {
+                "requests": {
+                  "type": "object",
+                  "default": {},
+                  "title": "The requests Schema",
+                  "properties": {
+                    "cpu": {
+                      "type": "string",
+                      "default": "",
+                      "title": "The cpu Schema"
+                    },
+                    "memory": {
+                      "type": "string",
+                      "default": "",
+                      "title": "The memory Schema"
+                    }
+                  },
+                  "examples": [{ "cpu": "25m", "memory": "50Mi" }]
+                }
+              },
+              "examples": [{ "requests": { "cpu": "25m", "memory": "50Mi" } }]
+            },
+            "backupFilename": {
+              "type": "string",
+              "default": "",
+              "title": "Specific backup filename to restore"
+            }
+          }
+        },
         "dummyData": {
           "type": "object",
           "default": {},

--- a/charts/exivity/values.yaml
+++ b/charts/exivity/values.yaml
@@ -323,6 +323,7 @@ service:
       accessModes: # Access modes for backup PVC
         - "ReadWriteOnce"
       volumeMode: "Filesystem" # Volume mode: "Filesystem" or "Block"
+      helmResourcePolicy: "keep" # Whether to keep or delete the PVC on Helm uninstall ("keep" or "delete")
       # Optional: selector for binding to specific persistent volumes
       # selector:
       #   matchLabels:
@@ -330,6 +331,32 @@ service:
       # Optional: additional annotations and labels for the PVC resource itself
       annotations: {} # Additional annotations for backup PVC
       labels: {} # Additional labels for backup PVC
+
+  # Configuration for the PostgreSQL restore job.
+  # This restore job allows manual restoration of database backups.
+  restore:
+    enabled: false # Whether to enable the restore job functionality
+    registry: ""
+    repository: exivity/db-backup
+    tag: ""
+    pullPolicy: ""
+    nodeName: ""
+    nodeSelector: {}
+    nodeAffinity: {}
+    tolerations: []
+    # securityContext:
+    #   runAsUser: 1000
+    #   runAsGroup: 1000
+    #   fsGroup: 1000
+    #   runAsNonRoot: true
+    resources:
+      requests:
+        cpu: "25m"
+        memory: "50Mi"
+    # Restore configuration
+    backupFilename: "" # Specific backup filename to restore (e.g., "backup-2023-01-01_12-00-00.sql")
+    # If backupFilename is empty, the restore job will restore the most recent backup
+    # Additional restore options
 
   # Configuration for the 'dummyData' service, used for deploying dummy data for testing purposes.
   dummyData:

--- a/charts/exivity/values.yaml
+++ b/charts/exivity/values.yaml
@@ -291,6 +291,46 @@ service:
     migration:
       resources: {} # Resources allocated for migration operations, define as needed.
 
+  # Configuration for the PostgreSQL backup job.
+  # This backup is only executed during Helm chart upgrades, not as a regular scheduled job.
+  backup:
+    enabled: true # Whether to run the backup job before migrations during upgrades
+    registry: ""
+    repository: exivity/db-backup
+    tag: ""
+    pullPolicy: ""
+    nodeName: ""
+    nodeSelector: {}
+    nodeAffinity: {}
+    tolerations: []
+    # securityContext:
+    #   runAsUser: 1000
+    #   runAsGroup: 1000
+    #   fsGroup: 1000
+    #   runAsNonRoot: true
+    resources:
+      requests:
+        cpu: "25m"
+        memory: "50Mi"
+    # Backup configuration
+    retentionDays: 7 # Number of days to retain backups
+    filePrefix: "backup" # Prefix for backup files
+    # Backup storage configuration
+    # This storage is independent from other PVCs and requires explicit configuration
+    storage:
+      size: "10Gi" # Size of the backup PVC
+      storageClass: "" # Custom storage class for backup PVC (if empty, uses cluster default)
+      accessModes: # Access modes for backup PVC
+        - "ReadWriteOnce"
+      volumeMode: "Filesystem" # Volume mode: "Filesystem" or "Block"
+      # Optional: selector for binding to specific persistent volumes
+      # selector:
+      #   matchLabels:
+      #     backup: "true"
+      # Optional: additional annotations and labels for the PVC resource itself
+      annotations: {} # Additional annotations for backup PVC
+      labels: {} # Additional labels for backup PVC
+
   # Configuration for the 'dummyData' service, used for deploying dummy data for testing purposes.
   dummyData:
     enabled: false

--- a/charts/exivity/values.yaml
+++ b/charts/exivity/values.yaml
@@ -294,7 +294,7 @@ service:
   # Configuration for the PostgreSQL backup job.
   # This backup is only executed during Helm chart upgrades, not as a regular scheduled job.
   backup:
-    enabled: true # Whether to run the backup job before migrations during upgrades
+    enabled: false # Whether to run the backup job before migrations during upgrades
     registry: ""
     repository: exivity/db-backup
     tag: ""


### PR DESCRIPTION
Introduce PostgreSQL backup and restore jobs to the Helm chart, including configuration options. Ensure the backup job runs only during upgrades and prevent simultaneous activation of backup and restore jobs. Refactor environment variable handling using ConfigMap and Secret for better management.

See: https://exivity.atlassian.net/browse/EXVT-6004