### PR TITLE
chore: Add PostgreSQL restore job configuration to values.yaml

### DIFF
--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -13,6 +13,7 @@ jobs:
         name:
           - chronos
           - db
+          - db-backup
           - edify
           - executor
           - glass

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -15,6 +15,7 @@ jobs:
         name:
           - chronos
           - db
+          - db-backup
           - edify
           - executor
           - glass

--- a/charts/exivity/values.yaml
+++ b/charts/exivity/values.yaml
@@ -332,7 +332,33 @@ service:
       # Optional: additional annotations and labels for the PVC resource itself
       annotations: {} # Additional annotations for backup PVC
       labels: {} # Additional labels for backup PVC
- 
+
+  # Configuration for the PostgreSQL restore job.
+  # This restore job allows manual restoration of database backups.
+  restore:
+    enabled: false # Whether to enable the restore job functionality
+    registry: ""
+    repository: exivity/db-backup
+    tag: ""
+    pullPolicy: ""
+    nodeName: ""
+    nodeSelector: {}
+    nodeAffinity: {}
+    tolerations: []
+    # securityContext:
+    #   runAsUser: 1000
+    #   runAsGroup: 1000
+    #   fsGroup: 1000
+    #   runAsNonRoot: true
+    resources:
+      requests:
+        cpu: "25m"
+        memory: "50Mi"
+    # Restore configuration
+    backupFilename: "" # Specific backup filename to restore (e.g., "backup-2023-01-01_12-00-00.sql")
+    # If backupFilename is empty, the restore job will restore the most recent backup
+    # Additional restore options
+
   # Configuration for the 'dummyData' service, used for deploying dummy data for testing purposes.
   dummyData:
     enabled: false


### PR DESCRIPTION
Introduce configuration options for a PostgreSQL restore job, allowing for manual restoration of database backups. The restore job can be enabled and customized through the values.yaml file.