### PR TITLE
chore: update deployment and api.env configuration

### DIFF
--- a/charts/exivity/templates/pigeon/deployment.yaml
+++ b/charts/exivity/templates/pigeon/deployment.yaml
@@ -62,14 +62,6 @@ spec:
             - secretRef:
                 name: {{ include "exivity.fullname" $ -}}-app-key
           env:
-            - name:  REDIS_HOST
-              value: exivity-redis-master
-            - name:  REDIS_PORT
-              value: "6379"
-            - name:  CACHE_DRIVER
-              value: redis
-            - name:  QUEUE_DRIVER
-              value: redis
             - name:  EXIVITY_BACKEND_LOG_LEVEL
               value: "{{ .Values.logLevel.backend }}"
             - name:  ENABLE_PROMETHEUS

--- a/charts/exivity/templates/proximity/api.env.yaml
+++ b/charts/exivity/templates/proximity/api.env.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/component: proximity-api
     {{- include "exivity.labels" $ | indent 4 }}
 data:
-  REDIS_HOST: exivity-redis-master
   CACHE_DRIVER: file
   QUEUE_CONNECTION: sync
   NGINX_LOG_PATH: /var/log/nginx


### PR DESCRIPTION
In this pr, removes all Redis configurations from the Helm chart.

Testing:
 Staging deployment successful
 Helm lint passes with zero Redis warnings
 All acceptance criteria met (templates, values, manifests clean)
 No Redis services or errors in application logs

CLOSE-[EXVT-6006](https://exivity.atlassian.net/browse/EXVT-6006)